### PR TITLE
support ddc.vim's suffix completion and fix bug to get line

### DIFF
--- a/autoload/ddc_tabnine/internal.vim
+++ b/autoload/ddc_tabnine/internal.vim
@@ -13,12 +13,12 @@ function! ddc_tabnine#internal#get_around(limit) abort
   let before_line = max([1, line - a:limit])
   let before_lines = getline(before_line, line)
   if len(before_lines) > 0
-    let before_lines[-1] = before_lines[-1][: col - 1]
+    let before_lines[-1] = before_lines[-1][: col - 2]
   endif
   let after_line = min([last_line, line + a:limit])
   let after_lines = getline(line, after_line)
   if len(after_lines) > 0
-    let after_lines[0] = after_lines[0][col :]
+    let after_lines[0] = after_lines[0][col - 1:]
   endif
 
   let filename = bufname()

--- a/denops/ddc-sources/tabnine.ts
+++ b/denops/ddc-sources/tabnine.ts
@@ -11,6 +11,7 @@ import { getAround } from "../ddc-tabnine/internal_autoload_fn.ts";
 
 type Params = {
   maxSize: number;
+  maxNumResults: number;
 };
 
 export class Source extends BaseSource {
@@ -27,7 +28,7 @@ export class Source extends BaseSource {
       regionIncludesEnd,
     ] = await getAround(args.denops, p.maxSize);
     const req: TabNineV2AutoCompleteRequest = {
-      maxNumResults: args.sourceOptions.maxCandidates,
+      maxNumResults: p.maxNumResults,
       filename,
       before,
       after,
@@ -44,7 +45,9 @@ export class Source extends BaseSource {
     const cs: Candidate[] =
       res?.results?.filter((e) => e?.new_prefix).map((e) => ({
         word: e.new_prefix,
+        abbr: e.new_prefix + (e.new_suffix ?? ""),
         menu: e.detail ?? undefined,
+        user_data: JSON.stringify(e),
       })) ?? [];
     return cs;
   }
@@ -52,6 +55,7 @@ export class Source extends BaseSource {
   params(): Params {
     return {
       maxSize: 200,
+      maxNumResults: 5,
     };
   }
 }

--- a/denops/ddc-sources/tabnine.ts
+++ b/denops/ddc-sources/tabnine.ts
@@ -35,6 +35,8 @@ export class Source extends BaseSource {
       regionIncludesBeginning,
       regionIncludesEnd,
     };
+    console.log(`_x_[XXX]_x_ eeeeeeeeee`);
+    console.log({ before, after });
     const resUnknown: unknown = await args.denops.dispatch(
       "ddc-tabnine",
       "internalRequestAutocomplete",

--- a/denops/ddc-tabnine/tabnine/client_base.ts
+++ b/denops/ddc-tabnine/tabnine/client_base.ts
@@ -74,7 +74,8 @@ export class TabNine {
     if (this.proc) {
       const oldProc = this.proc;
       this.proc = undefined;
-      oldProc.kill(Deno.Signal.SIGINT);
+      // deno-lint-ignore no-explicit-any
+      (oldProc.kill as any)((Deno as any).Signal?.SIGINT ?? "SIGINT");
     }
     const args = [
       `--client=${this.clientName}`,
@@ -167,7 +168,10 @@ export class TabNine {
   }
 
   close() {
-    this.proc?.kill(Deno.Signal.SIGINT);
+    if (this.proc) {
+      // deno-lint-ignore no-explicit-any
+      (this.proc.kill as any)((Deno as any).Signal?.SIGINT ?? "SIGINT");
+    }
   }
 
   static async getLatestVersion(): Promise<string> {

--- a/doc/ddc-tabnine.txt
+++ b/doc/ddc-tabnine.txt
@@ -50,6 +50,7 @@ EXAMPLES						*ddc-tabnine-examples*
 	    \ }})
 	call ddc#custom#patch_global('sourceParams', {
 	    \ 'tabnine': {
+	    \   'maxNumResults': 10,
 	    \   'storageDir': expand('~/.cache/....'),
 	    \ }})
 <
@@ -82,6 +83,14 @@ ddc_tabnine#disable_auto_install	(boolean)
 		ensure the binary existence.
 
 		Default: |v:false|
+
+					     *ddc-tabnine-param-maxNumResults*
+maxNumResults	(number)
+		Max number of results to retrieve. This is natively 
+		implemented by TabNine and run before filtering compared to
+		|ddc-source-option-maxCandidates|.
+
+		Default: 5
 
 
 ==============================================================================


### PR DESCRIPTION
- support ddc.vim's suffix completion. https://github.com/Shougo/ddc.vim/commit/fc082db816d103dbfa7266a82a9ddcb85dfce31c ~
- fix bug to get line (col - 1 → col - 2)
- revert maxNumResults param.
- `abbr` update
- fix for deno v1.14