### PR TITLE
Fix windows installation issues

### DIFF
--- a/denops/ddc-tabnine/tabnine/client_base.ts
+++ b/denops/ddc-tabnine/tabnine/client_base.ts
@@ -133,11 +133,18 @@ export class TabNine {
       try {
         const reader = io.readerFromStreamReader(res.body.getReader());
         await io.copy(reader, destFile);
-        await decompress(zipPath, destDir);
       } finally {
         destFile.close();
       }
-      await Deno.remove(zipPath);
+      try {
+        if (!(await decompress(zipPath, destDir))) {
+          throw new Error("failed to decompress a TabNine archive");
+        }
+      } catch (e: unknown) {
+        throw e;
+      } finally {
+        await Deno.remove(zipPath);
+      }
     }
     for await (const entry of await Deno.readDir(destDir)) {
       await Deno.chmod(path.resolve(destDir, entry.name), 0o755);

--- a/denops/ddc-tabnine/tabnine/client_base.ts
+++ b/denops/ddc-tabnine/tabnine/client_base.ts
@@ -146,6 +146,9 @@ export class TabNine {
         await Deno.remove(zipPath);
       }
     }
+    if (Deno.build.os === "windows") {
+      return;
+    }
     for await (const entry of await Deno.readDir(destDir)) {
       await Deno.chmod(path.resolve(destDir, entry.name), 0o755);
     }


### PR DESCRIPTION
This PR fixes the following errors:

1. an error that occurred when `decompress` was called before a zip file was closed
2. an error caused by `chmod`, which is not supported on Windows ([Deno.chmod](https://doc.deno.land/deno/stable/~/Deno.chmod#:~:text=NOTE%3A%20This%20API%20currently%20throws%20on%20Windows))

**Note**

Before e8ee08069bfd9b97ce482e478dfa8faaebff4655, the following error was logged in `:messages`
```
[denops] [ddc-tabnine] Installing TabNine cli version 4.4.139...

[denops] New-Object : Exception calling ".ctor" with "3" argument(s): "The process cannot access the file 'C:\Users\blyoa\AppDat
[denops] a\Local\xdg.cache\ddc-tabnine\binaries\4.4.139\x86_64-pc-windows-gnu\TabNine.zip' because it is being used by another 
[denops] process."
[denops] At C:\WINDOWS\system32\WindowsPowerShell\v1.0\Modules\Microsoft.PowerShell.Archive\Microsoft.PowerShell.Archive.psm1:93
[denops] 1 char:30
[denops] + ... ileStream = New-Object -TypeName System.IO.FileStream -ArgumentList $ ...
[denops] +                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
[denops]     + CategoryInfo          : InvalidOperation: (:) [New-Object], MethodInvocationException
[denops]     + FullyQualifiedErrorId : ConstructorInvokedThrowException,Microsoft.PowerShell.Commands.NewObjectCommand
[denops]  
[ddc] source: tabnine "gather()" failed
```