### PR TITLE
Update dependencies and replace deprecated methods and classes

### DIFF
--- a/denops/ddc-tabnine/deps.ts
+++ b/denops/ddc-tabnine/deps.ts
@@ -1,11 +1,11 @@
-export type { Item } from "https://deno.land/x/ddc_vim@v3.1.0/types.ts";
-export { BaseSource } from "https://deno.land/x/ddc_vim@v3.1.0/types.ts";
-export type { Denops } from "https://deno.land/x/ddc_vim@v3.1.0/deps.ts";
-export { fn, vars } from "https://deno.land/x/ddc_vim@v3.1.0/deps.ts";
+export type { Item } from "https://deno.land/x/ddc_vim@v4.1.0/types.ts";
+export { BaseSource } from "https://deno.land/x/ddc_vim@v4.1.0/types.ts";
+export type { Denops } from "https://deno.land/x/ddc_vim@v4.1.0/deps.ts";
+export { fn, vars } from "https://deno.land/x/ddc_vim@v4.1.0/deps.ts";
 export type {
   GatherArguments,
   OnCompleteDoneArguments,
-} from "https://deno.land/x/ddc_vim@v3.1.0/base/source.ts";
+} from "https://deno.land/x/ddc_vim@v4.1.0/base/source.ts";
 export * as path from "https://deno.land/std@0.107.0/path/mod.ts";
 export * as io from "https://deno.land/std@0.107.0/io/mod.ts";
 export * as fs from "https://deno.land/std@0.107.0/fs/mod.ts";

--- a/denops/ddc-tabnine/deps.ts
+++ b/denops/ddc-tabnine/deps.ts
@@ -12,6 +12,6 @@ export * as fs from "https://deno.land/std@0.206.0/fs/mod.ts";
 export { decompress } from "https://deno.land/x/zip@v1.2.1/mod.ts";
 export * as semver from "https://deno.land/x/semver@v1.4.0/mod.ts";
 export { Mutex } from "https://deno.land/x/semaphore@v1.1.0/mod.ts";
-export { assert } from "https://deno.land/std@0.107.0/testing/asserts.ts";
+export { assert } from "https://deno.land/std@0.206.0/assert/assert.ts";
 import xdg from "https://deno.land/x/xdg@v9.4.0/src/mod.deno.ts";
 export { xdg };

--- a/denops/ddc-tabnine/deps.ts
+++ b/denops/ddc-tabnine/deps.ts
@@ -6,9 +6,9 @@ export type {
   GatherArguments,
   OnCompleteDoneArguments,
 } from "https://deno.land/x/ddc_vim@v4.1.0/base/source.ts";
-export * as path from "https://deno.land/std@0.107.0/path/mod.ts";
-export * as io from "https://deno.land/std@0.107.0/io/mod.ts";
-export * as fs from "https://deno.land/std@0.107.0/fs/mod.ts";
+export * as path from "https://deno.land/std@0.206.0/path/mod.ts";
+export * as io from "https://deno.land/std@0.206.0/io/mod.ts";
+export * as fs from "https://deno.land/std@0.206.0/fs/mod.ts";
 export { decompress } from "https://deno.land/x/zip@v1.2.1/mod.ts";
 export * as semver from "https://deno.land/x/semver@v1.4.0/mod.ts";
 export { Mutex } from "https://deno.land/x/semaphore@v1.1.0/mod.ts";

--- a/denops/ddc-tabnine/deps.ts
+++ b/denops/ddc-tabnine/deps.ts
@@ -9,6 +9,7 @@ export type {
 export * as path from "https://deno.land/std@0.206.0/path/mod.ts";
 export * as io from "https://deno.land/std@0.206.0/io/mod.ts";
 export * as fs from "https://deno.land/std@0.206.0/fs/mod.ts";
+export { TextLineStream } from "https://deno.land/std@0.206.0/streams/mod.ts";
 export { decompress } from "https://deno.land/x/zip@v1.2.1/mod.ts";
 export * as semver from "https://deno.land/x/semver@v1.4.0/mod.ts";
 export { Mutex } from "https://deno.land/x/semaphore@v1.1.0/mod.ts";

--- a/denops/ddc-tabnine/tabnine/client_base.ts
+++ b/denops/ddc-tabnine/tabnine/client_base.ts
@@ -1,15 +1,5 @@
 import { assert, decompress, fs, io, Mutex, path, semver } from "../deps.ts";
 
-// https://github.com/denoland/deno_std/issues/1216
-const exists = async (filePath: string): Promise<boolean> => {
-  try {
-    await Deno.lstat(filePath);
-    return true;
-  } catch (_e: unknown) {
-    return false;
-  }
-};
-
 export class TabNine {
   private proc?: Deno.Process;
   private lines?: AsyncIterator<string>;
@@ -106,7 +96,7 @@ export class TabNine {
       archAndPlatform,
       Deno.build.os === "windows" ? "TabNine.exe" : "TabNine",
     );
-    return await exists(destDir);
+    return await fs.exists(destDir);
   }
 
   static async installTabNine(
@@ -171,7 +161,7 @@ export class TabNine {
       version,
       archAndPlatform,
     );
-    if (await exists(destDir)) {
+    if (await fs.exists(destDir)) {
       await Deno.remove(destDir, { recursive: true });
     }
   }
@@ -198,11 +188,11 @@ export class TabNine {
   static async getInstalledVersions(storageDir: string): Promise<string[]> {
     const versions: string[] = [];
     const archAndPlatform = TabNine.getArchAndPlatform();
-    if (!(await exists(storageDir))) return [];
+    if (!(await fs.exists(storageDir))) return [];
     for await (const version of Deno.readDir(storageDir)) {
       if (
         semver.valid(version.name) &&
-        await exists(
+        await fs.exists(
           path.join(
             storageDir,
             version.name,
@@ -239,7 +229,7 @@ export class TabNine {
         archAndPlatform,
         Deno.build.os == "windows" ? "TabNine.exe" : "TabNine",
       );
-      if (await exists(fullPath)) {
+      if (await fs.exists(fullPath)) {
         return fullPath;
       } else {
         tried.push(fullPath);

--- a/denops/ddc-tabnine/tabnine/client_base.ts
+++ b/denops/ddc-tabnine/tabnine/client_base.ts
@@ -139,7 +139,7 @@ export class TabNine {
     if (Deno.build.os === "windows") {
       return;
     }
-    for await (const entry of await Deno.readDir(destDir)) {
+    for await (const entry of Deno.readDir(destDir)) {
       await Deno.chmod(path.resolve(destDir, entry.name), 0o755);
     }
   }


### PR DESCRIPTION
[The latest ddc.vim](https://github.com/Shougo/ddc.vim/tree/c80d20daa8df26dd2ee1f62dd8d5db60b70fe43e) shows the following message to ddc-tabnine, and ddc-tabnine does not work with the latest ddc.vim.

```
[ddc] source is too old: "tabnine"
```

This PR:

- updates ddc.vim to make ddc-tabnine work with the latest ddc.vim
- updates standard packages
- replaces deprecated methods and classes